### PR TITLE
Automatically find available ports for foreman

### DIFF
--- a/bin/find_unused_port
+++ b/bin/find_unused_port
@@ -1,0 +1,17 @@
+#!/bin/zsh
+
+# Find a TCP port that is not being used so that we can bind a server to that
+# port.
+#
+# On success, echoes the port number and exits 0.
+# On failure, prints nothing and exits 1.
+
+for port in 4000 5000 6000 7000 8000 9000; do
+  if is_port_unused "$port"; then
+    echo "$port"
+    exit 0
+  fi
+done
+
+# We made it through without finding a port :/
+exit 1

--- a/bin/is_port_unused
+++ b/bin/is_port_unused
@@ -1,0 +1,11 @@
+#!/bin/zsh
+
+# Find out if $1 is in use as a TCP port.
+# Exits 0 if it's available.
+# Exits 1 if it's not.
+
+ports_in_use="$(lsof -iTCP -sTCP:LISTEN -n -P -F n | egrep '^n' | sed -E -e 's/^n//' -e 's/^.*:([0-9]+)$/\1/' | sort -u)"
+
+port="$1"
+
+! grep -qF "$port" <<<"$ports_in_use"

--- a/bin/start_foreman_on_unused_port
+++ b/bin/start_foreman_on_unused_port
@@ -1,0 +1,29 @@
+#!/bin/zsh
+
+# Start foreman (or forego, if it's available) on an unused port.
+# If there's a .foreman file, it tries that port first, then falls back to
+# finding another unused port.
+#
+# If it can't find an unused port at all, prints an error and exits 1.
+#
+# It uses the `is_port_unused` and `find_unused_port` scripts, which are both in
+# this directory.
+
+if command -v forego > /dev/null; then
+  command_name=forego
+else
+  command_name=foreman
+fi
+
+port_from_foreman="$(grep port: .foreman 2>/dev/null| sed 's/port: //')"
+
+if is_port_unused "$port_from_foreman"; then
+  $command_name start -p "$port_from_foreman"
+else
+  if find_unused_port; then
+    $command_name start -p "$(find_unused_port)"
+  else
+    echo "Couldn't find an unused port :("
+    exit 1
+  fi
+fi

--- a/zsh/rails.zsh
+++ b/zsh/rails.zsh
@@ -11,3 +11,5 @@ alias rrg="be rake routes | grep"
 
 # Database
 alias db-reset="be rake db:drop db:create && migrate"
+
+alias f=start_foreman_on_unused_port


### PR DESCRIPTION
* `is_port_unused` takes a port like "4000" as its first argument and exits 0
  if it's available, or 1 if it's not.
* `find_unused_port` checks ports 4000/5000/6000/7000/8000/9000 and echoes the
  first one that's unused. If all of them are in use, it exits 1.
* `start_foreman_on_unused_port` uses the above scripts to find an unused port.
  It first tries the port in the `.foreman` file (if available), then uses
  `find_unused_port` to find an unused port. It uses `forego`, the Go port of
  foreman, if it's available, and falls back to plain old `foreman` otherwise.

`f` is a convenient alias for `start_foreman_on_unused_port`.