### PR TITLE
Use ftplugin and ftdetect correctly

### DIFF
--- a/vim/autocommand.vim
+++ b/vim/autocommand.vim
@@ -7,32 +7,6 @@ augroup myfiletypes
   " and not leave the "!"
   au FileType ruby,eruby,yaml set iskeyword+=!,?
   au FileType ruby,eruby,yaml set isfname=_,-,48-57,A-Z,a-z,/
-
-  " Haskell has 4-space tabs
-  au FileType haskell set shiftwidth=4
-
-  " Tabs
-  au FileType go set noexpandtab tabstop=4 shiftwidth=4
-
-  " .step files are Ruby
-  au BufRead,BufNewFile *.step setf ruby
-
-  " .json.jbuilder files are Ruby
-  au BufNewFile,BufRead *.json.jbuilder setf ruby
-
-  " treat extra files like ruby
-  au BufRead,BufNewFile *.ru,Gemfile,Guardfile,.simplecov setf ruby
-
-  " It's Markdown, not modula2, you infernal machine
-  au BufRead,BufNewFile *.md set syntax=markdown filetype=markdown
-  au BufRead,BufNewFile *.coffee set syntax=coffee
-  au BufRead,BufNewFile *.go setf go
-  au BufNewFile,BufRead .tmux.conf*,tmux.conf* setf tmux
-
-  " .gitconfig and gitconfig are the same
-  au BufRead,BufNewFile gitconfig set syntax=gitconfig
-
-  au BufRead /usr/share/file/magic/* set syntax=magic
 augroup END
 
 " When editing a file, always jump to the last known cursor position.

--- a/vim/ftdetect/gitconfig.vim
+++ b/vim/ftdetect/gitconfig.vim
@@ -1,0 +1,2 @@
+" .gitconfig and gitconfig are the same
+au BufRead,BufNewFile gitconfig set syntax=gitconfig

--- a/vim/ftdetect/magic.vim
+++ b/vim/ftdetect/magic.vim
@@ -1,0 +1,1 @@
+au BufRead /usr/share/file/magic/* set syntax=magic

--- a/vim/ftdetect/markdown.vim
+++ b/vim/ftdetect/markdown.vim
@@ -1,0 +1,2 @@
+" It's Markdown, not modula2, you infernal machine
+au BufRead,BufNewFile *.md set syntax=markdown filetype=markdown

--- a/vim/ftdetect/ruby.vim
+++ b/vim/ftdetect/ruby.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.ru,Gemfile,Guardfile,.simplecov,*.step,*.json.jbuilder setf ruby

--- a/vim/ftdetect/tmux.vim
+++ b/vim/ftdetect/tmux.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead .tmux.conf*,tmux.conf* setf tmux

--- a/vim/ftplugin/go.vim
+++ b/vim/ftplugin/go.vim
@@ -1,0 +1,1 @@
+set noexpandtab tabstop=4 shiftwidth=4

--- a/vim/ftplugin/haskell.vim
+++ b/vim/ftplugin/haskell.vim
@@ -1,0 +1,2 @@
+" Haskell has 4-space tabs
+set shiftwidth=4


### PR DESCRIPTION
Vim sources `ftdetect/*.vim` for every file, because it doesn't know which one will set the filetype.

However, it only loads `ftplugin/FILETYPE.vim`, i.e. it only loads the single correct `ftplugin` file.