### PR TITLE
Turn off ZSH's MULTIOS option

### DIFF
--- a/zsh/options.zsh
+++ b/zsh/options.zsh
@@ -19,3 +19,5 @@ unsetopt correctall
 # Allow [ or ] wherever you want
 # (Prevents "zsh: no matches found: ...")
 unsetopt nomatch
+
+unsetopt multios


### PR DESCRIPTION
Documentation on the option: http://zsh.sourceforge.net/Doc/Release/Redirection.html#Multios

The option is on by default: http://linux.die.net/man/1/zshoptions

Essentially, the `MULTIOS` option means that this:

    echo something >& 1 | other_command

will output to FD 1 _and_ pipe the output to `other_command`, rather than only
piping it.

Here's what the output of ZSH with the `MULTIOS` option looks like:

    # ZSH with MULTIOS option on
    $ echo "hello there" >& 1 | sed "s/hello/hi/"
    hi there
    hi there
    $ echo "hello there" >& 2 | sed "s/hello/hi/"
    hello there
    hi there

It's bizarre behavior that bites you when you least expect it.