### PR TITLE
Add gundo.vim

### DIFF
--- a/vim/vundle.vim
+++ b/vim/vundle.vim
@@ -48,6 +48,7 @@ Plug 'slim-template/vim-slim'
 " gives you an `ae` text object, so `gcae` comments whole file
 Plug 'kana/vim-textobj-entire'
 Plug 'pbrisbin/vim-runfile'
+Plug 'vim-scripts/Gundo'
 
 " Haskell
 Plug 'scrooloose/syntastic'


### PR DESCRIPTION
It uses Python.

To get it to install on OS X, uninstall Homebrew-installed Pythons:

    brew uninstall python python3