### PR TITLE
Auto-copy URL for newly opened PR

### DIFF
--- a/bin/git-create-pull-request
+++ b/bin/git-create-pull-request
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Open a PR and copy the url to the clipboard
+
+set -e
+
+commit_message_file="$(mktemp -t commit_message_file)"
+
+# Put some space at the top
+echo >> "$commit_message_file"
+
+number_of_commits=$(git rev-list master..HEAD --count)
+
+if [ "$number_of_commits" -eq 1 ]; then
+  git log -1 --format=%B >> "$commit_message_file"
+else
+  git log --format="%h (%aN, %ar)%n%w(78,3,3)%s%n%+b" master..HEAD | sed 's/^/# /' >> "$commit_message_file"
+fi
+
+# Start vim in insert mode
+vim -c "startinsert" -c "set ft=gitcommit" "$commit_message_file"
+
+message_without_comments="$(egrep -v "^#" "$commit_message_file")"
+
+hub pull-request -m "$message_without_comments" | pbcopy
+
+echo "Pull request URL was copied to the clipboard: $(pbpaste)"

--- a/tag-git/gitconfig
+++ b/tag-git/gitconfig
@@ -39,8 +39,8 @@
   r = rebase -i origin/master
   newauthor = commit --amend --reset-author -C HEAD
   next = !git add . && git rebase --continue
-  pr = !git push -u && hub pull-request
-  prf = !git push -u --force && hub pull-request
+  pr = !git push -u && git create-pull-request
+  prf = !git push -u --force && git create-pull-request
   pf = push --force-with-lease
   g = grep --extended-regexp --break --heading --line-number
   ss = !git shalector | xargs git show


### PR DESCRIPTION
This lets me use Vim to write the commit message with all of the commits shown (just like `hub pull-request`) but still get the URL of the pull request automatically copied.

Fixes #17.

Thanks @gfontenot!