### PR TITLE
Extreme powerups for connecting to a tmux session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # dotfiles
 
-![prompt](https://cloud.githubusercontent.com/assets/257678/10357733/7304816e-6d3a-11e5-98d6-010cd3fc38d4.png)
-
 Gabriel Berke-Williams' dotfiles for Zsh, ruby, git, and more.
 
 Questions? Comments? Open an issue or tweet [@gabebw](https://twitter.com/gabebw).

--- a/bin/projects
+++ b/bin/projects
@@ -1,0 +1,26 @@
+#!/bin/zsh
+
+# List all directories in $CDPATH that have been modified in the last N days
+# and contain git repositories.
+
+cdpath_directories() {
+  local days_since_modified=90
+
+  echo "${CDPATH//:/\n}" | while read dir; do
+    find -L "$dir" \
+      -not -path '*/\.*' \
+      -type d \
+      -mtime -$days_since_modified \
+      -maxdepth 1
+  done
+}
+
+is_a_git_repo(){
+  while read dir; do
+    if [[ -d "$dir/.git" ]]; then
+      basename "$dir"
+    fi
+  done
+}
+
+cdpath_directories | is_a_git_repo

--- a/tag-tmux/bin/t
+++ b/tag-tmux/bin/t
@@ -1,0 +1,68 @@
+#!/bin/zsh
+
+### ~*~ t ~*~ ###
+# Use `t blog` to connect to the `blog` session, or create a new session named
+# `blog`.
+#
+# With no arguments, fuzzy-finds a session in a directory in $CDPATH.
+
+_not_in_tmux(){
+  [[ -z "$TMUX" ]]
+}
+
+# Attach if not in tmux, or switch if we are in tmux
+_attach_to_tmux_session() {
+  session=$1
+
+  if _not_in_tmux; then
+    tmux attach -d -t "$session"
+  else
+    tmux switch-client -t "$session"
+  fi
+}
+
+_tmux_session_exists(){
+  tmux list-sessions -F "#{session_name}" | egrep -q "^${1}$"
+}
+
+# Create a new tmux session with the given name.
+_new_tmux_session_named() {
+  new_session_name=${1//./-}
+
+  # Create three windows named vim/scratch/server and jump into the first one
+  TMUX='' tmux new-session -d -As "$new_session_name" -n vim
+  tmux new-window -t "$new_session_name" -n scratch
+  tmux new-window -t "$new_session_name" -n server
+  tmux select-window -t "$new_session_name" -n
+  _attach_to_tmux_session "$new_session_name"
+}
+
+# Try to connect to a tmux session with the given name.
+# If no such session exists, create it first.
+_tmux_try_to_connect_to(){
+  session_to_connect_to=${1//./-}
+
+  if _tmux_session_exists "$session_to_connect_to"; then
+    _attach_to_tmux_session "$session_to_connect_to"
+  else
+    _new_tmux_session_named "$session_to_connect_to"
+  fi
+}
+
+_current_tmux_session(){
+  tmux ls -F '#S #{session_attached}' | grep 1$ | cut -d' ' -f1
+}
+
+if (( $# == 1 )); then
+  _tmux_try_to_connect_to "$1"
+else
+  project=$(projects | fzf --reverse)
+
+  if [[ -n "$project" && "$project" != "$(_current_tmux_session)" ]]; then
+    if _tmux_session_exists "$project"; then
+      tmux attach -t "$project"
+    else
+      (cd "$project" && _new_tmux_session_named "$project")
+    fi
+  fi
+fi

--- a/tag-tmux/zsh/navigation.zsh
+++ b/tag-tmux/zsh/navigation.zsh
@@ -11,7 +11,11 @@ function current-project-path() {
   echo "${TMUX_PROJECT_DIRECTORY}/${current_tmux_session}"
 }
 
+# Use the lowercase version to create as an array, and export the uppercase
+# version. The lowercase version can't be exported, and the uppercase version
+# can't be set to an array.
 cdpath=($HOME/code $HOME/code/* $HOME/code/thoughtbot/*)
+export CDPATH
 
 function chpwd {
   echo "$(pwd)" >! "$(current-project-path)"

--- a/tag-tmux/zsh/tmux.zsh
+++ b/tag-tmux/zsh/tmux.zsh
@@ -1,6 +1,4 @@
-####################################
-# 1) Ensure we're always in a tmux session
-
+# Ensure we're always in a tmux session
 ensure_we_are_inside_tmux() {
   if _not_in_tmux; then
     _ensure_tmux_is_running
@@ -31,57 +29,4 @@ _ensure_tmux_is_running() {
     # `tmux attach` can use.
     tmux new -d
   fi
-}
-
-# Attach if not in tmux, or switch if we are in tmux
-attach_to_tmux_session() {
-  local session="$1"
-  if _not_in_tmux; then
-    tmux attach -d -t "$1"
-  else
-    tmux switch-client -t "$1"
-  fi
-}
-
-####################################
-# 2) the `t` function
-
-# Use `t blog` to connect to the `blog` session, or create a new session named
-# `blog`.
-#
-# With no arguments, lists all tmux sessions.
-function t {
-  if (( $# == 1 )); then
-    _tmux_try_to_connect_to "$1"
-  else
-    tmux list-sessions -F "#{session_name}"
-  fi
- }
-
-_tmux_session_exists(){
-  tmux list-sessions -F "#{session_name}" | egrep -q "^${1}$"
-}
-
-# Try to connect to a session with the given name.
-# If no such session exists, create it first.
-_tmux_try_to_connect_to() {
-  local session_to_connect_to="${1//./-}"
-
-  if _tmux_session_exists "$session_to_connect_to"; then
-    attach_to_tmux_session "$session_to_connect_to"
-  else
-    _new_tmux_session_named "$session_to_connect_to"
-  fi
-}
-
-# Create a new tmux session with the given name.
-_new_tmux_session_named() {
-  local new_session_name="$1"
-
-  # Create three windows named vim/scratch/server and jump into the first one
-  TMUX= tmux new-session -d -As "$new_session_name" -n vim
-  tmux new-window -t "$new_session_name" -n scratch
-  tmux new-window -t "$new_session_name" -n server
-  tmux select-window -t "$new_session_name" -n
-  tmux attach -t "$session_name"
 }


### PR DESCRIPTION
`t` by itself opens up a fuzzy-find of project directories, then starts a tmux session named after the selected directory. If already in the selected session, does nothing.

`t foo` will connect to the tmux session named `foo`, or start a `foo` session if it doesn't exist.

`t` also tab-completes to existing sessions.

* Extract `t` to its own script, and move associated functions in as well for better encapsulation
* Create a `projects` script (thanks @christoomey!) that lists all directories in `$CDPATH` that have git directories and were modified recently