### PR TITLE
Let vim-tmux-navigator handle buffer navigation

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -230,12 +230,6 @@ nnoremap K :NewGrep '\b<C-R>=expand("<cword>")<CR>\b'<CR>
 " Only have the current split and tab open
 nnoremap <Leader>o :silent only<CR>
 
-" Buffer navigation
-nnoremap <C-j> <C-W>j
-nnoremap <C-k> <C-W>k
-nnoremap <C-l> <C-W>l
-nnoremap <C-h> <C-W>h
-
 " Movement
 " move vertically by _visual_ line
 nnoremap j gj


### PR DESCRIPTION
These lines were leading to an _incredibly_ frustrating situation:

* When Vim started, <C-j> etc were correctly set to use the vim-tmux-navigator mappings. (Which is actually kind of surprising, because these lines setting <C-j> are _after_ the vim-plug lines.)
* When the vimrc was re-sourced, vim-tmux-navigator was NOT reloaded since like many Vim plugins it sets a global variable on first load and if it's set, does not reload.
* However, these 4 lines _were_ run when I re-sourced my vimrc, and they overwrote vim-tmux-navigator's mappings.

That meant that every time I re-sourced my vimrc, I lost the ability to move from Vim to tmux.

And now, at last, it's fixed.