### PR TITLE
Vim: Switch back to Ag for grepping

### DIFF
--- a/agignore
+++ b/agignore
@@ -1,0 +1,1 @@
+searchignore

--- a/vimrc
+++ b/vimrc
@@ -372,8 +372,12 @@ set noerrorbells visualbell t_vb=
 set complete+=kspell
 set spellfile=$HOME/.vim/vim-spell-en.utf-8.add
 
-" Use ripgrep if it's installed, otherwise fall back to grep
-if executable("rg")
+if executable("ag")
+  " The silver searcher
+  set grepprg=ag\ --vimgrep
+  set grepformat=%f:%l:%c:%m
+elseif executable("rg")
+  " ripgrep
   set grepprg=rg\ --hidden\ --vimgrep\ --with-filename\ --ignore-file\ ~/.searchignore
   set grepformat=%f:%l:%c:%m
 else


### PR DESCRIPTION
When searching (which is synchronous), Ag returns control to Vim much faster than ripgrep.

I don't know if Ag is strictly _faster_ than ripgrep (they're tied when running on the command line), but it returns quickfix results almost twice as fast as ripgrep. Maybe it's a buffering thing, maybe it's a "running under Vim" thing, but Ag is perceptibly faster than Vim by 4+ seconds on large projects.