### PR TITLE
Vim: don't change `isfname` so that `gx` works

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -144,7 +144,6 @@ augroup vimrc
   " Include ! as a word character, so dw will delete all of e.g. gsub!,
   " and not leave the "!"
   au FileType ruby,eruby,yaml set iskeyword+=!,?
-  au FileType ruby,eruby,yaml set isfname=_,-,48-57,A-Z,a-z,/
   au BufNewFile,BufRead,BufWrite *.md,*.markdown,*.html syntax match Comment /\%^---\_.\{-}---$/
   autocmd VimResized * wincmd =
 augroup END


### PR DESCRIPTION
I was [so confused][0] about why (and when) `gx` in Vim was breaking. It intermittently broke with no discernible pattern. And then I realized:

`gx` broke (and continues to break) only in Ruby, Erb, and Yaml files because of this line:

    au FileType ruby,eruby,yaml set isfname=_,-,48-57,A-Z,a-z,/

`isfname` determines which characters count as filenames, and so messed up `gx`'s default `<cfile>` expansion. This was added 6 years ago in aca89699366525195c743fbff6b02f30ce08ea68 with a frankly unhelpful commit message, so I'm just going to remove it.

I cannot express how satisfying it is to finally solve this mystery!

[0]: https://github.com/gfontenot/dotfiles/commit/7ac07e2a42135b61de290c933f1ee0b0325c64b8