### PR TITLE
Use OSX's built-in Zsh

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -49,6 +49,9 @@ brew 'phantomjs'
 # Fast GitHub client, used in git-create-pull-request
 brew 'hub'
 
+# Don't install completions, in favor of using Zsh's (better) git completions
+brew 'git', args: ['--without-completions']
+
 # Fuzzy finder
 brew 'fzf'
 
@@ -56,10 +59,6 @@ brew 'fzf'
 tap 'thoughtbot/formulae'
 brew 'rcm'
 brew 'parity'
-
-# Install zsh 5.2+ (OS X ships with 5.0) to fix this issue:
-# https://github.com/robbyrussell/oh-my-zsh/issues/4932
-brew 'zsh'
 
 # The latest version of Docker is too new to work with Heroku's Docker registry.
 # Install Docker 1.11 instead, which is old enough to work with Heroku.
@@ -77,9 +76,3 @@ brew 'elasticsearch'
 brew 'youtube-dl'
 # youtube-dl uses ffmpeg to automatically fix some issues in downloaded files
 brew 'ffmpeg'
-
-if ENV.fetch("SHELL", "") != "/usr/local/bin/zsh"
-  puts "To use the Homebrew-installed ZSH:"
-  puts "  sudo echo /usr/local/bin/zsh >> /etc/shells"
-  puts "  chsh -s /usr/local/bin/zsh"
-end

--- a/install.sh
+++ b/install.sh
@@ -38,11 +38,7 @@ fi
 
 if ! echo $SHELL | grep -Fq zsh; then
   echo "Your shell is not Zsh. Changing it to Zsh..."
-  new_shell=$(which zsh)
-  # $(which zsh) is a new shell that didn't come with the system, so tell the
-  # system about it by adding it to /etc/shells
-  echo "$new_shell" | sudo tee -a /etc/shells
-  chsh -s "$new_shell"
+  chsh -s /bin/zsh
 fi
 
 echo "Linking dotfiles into ~..."


### PR DESCRIPTION
I recently restored my files to a new computer, but didn't copy over /usr/local.

When I signed in, my $SHELL was set to /usr/local/bin/zsh, which didn't exist, and so Terminal.app exited immediately upon opening. I had to use iTerm (with a custom profile that overrode my user's $SHELL) in order to log in and change my shell back to /bin/zsh in order to do anything.

Obviously this was a total nightmare. To fix it:

* Don't install Zsh via Homebrew at all. OSX ships with Zsh 5.2 now, which a comment from Past Gabe implies was the whole reason to use Homebrew-provided Zsh.
* Set my shell to the ever-present /bin/zsh to prevent the above nightmare from recurring.