### PR TITLE
Supercharge keybindings

### DIFF
--- a/tag-tmux/tmux.conf
+++ b/tag-tmux/tmux.conf
@@ -7,8 +7,10 @@ set -g prefix C-a
 # Make pbcopy/pbpaste and Vim's * register work.
 set -g default-command "reattach-to-user-namespace -l zsh"
 
-# act like vim
-set -g status-keys vi
+# Use emacs (readline) bindings to navigate the tmux command line (`<prefix>:`)
+set -g status-keys emacs
+
+# Use vim bindings to navigate paste mode
 setw -g mode-keys vi
 
 # improve colors

--- a/zshrc
+++ b/zshrc
@@ -275,6 +275,19 @@ compdef _vdot vdot
 # other `bindkey`s after it to override anything you like.
 bindkey -v
 
+# Open current command in Vim
+autoload -z edit-command-line
+zle -N edit-command-line
+bindkey "^v" edit-command-line
+
+# Copy the most recent command to the clipboard
+_pbcopy_last_command(){
+  fc -ln -1 | pbcopy && \
+    tmux display-message "Previous command copied to clipboard"
+}
+zle -N pbcopy-last-command _pbcopy_last_command
+bindkey '^x^x' pbcopy-last-command
+
 # Fuzzy match against history, edit selected value
 # For exact match, start the query with a single quote: 'curl
 fuzzy-history() {


### PR DESCRIPTION
* Add some insanely useful Zsh commands: edit the current command in
  Vim! Copy the most recent command to the clipboard! I was all set to
  switch my tmux prefix from `<C-a>` to `<C-s>` just to get
  emacs/readline `<C-a>`-as-beginning-of-line back. But editing the
  command in Vim is even better! (And doesn't require me to change my
  muscle memory.)
* Use emacs bindings in tmux command prompt