### PR TITLE
Don't set Ruby for Vim

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -6,9 +6,3 @@ is_osx(){
 
 # Add the Homebrew path here so that Vim can find Homebrew's ctags.
 PATH=/usr/local/bin:/usr/local/sbin:$PATH
-
-# Make sure rbenv is in the $PATH when we run `rbenv` below, and thus Vim's ruby
-# is correctly set
-PATH=./bin/stubs:~/.rbenv/shims:~/.rbenv/bin:$PATH
-
-eval "$(rbenv init -)"

--- a/zshrc
+++ b/zshrc
@@ -223,11 +223,8 @@ PATH=$HOME/.bin:$PATH
 # * ~/.rbenv/shims is before /usr/local/bin etc
 # * I don't know why it has to be in this order but putting shims before stubs
 #   breaks stubs ("You have activated the wrong version of rake" error)
-# * Yes, `rbenv init` adds ~/.rbenv/shims to the $PATH, but because it runs in
-#   zshenv, a lot of other things add $PATH entries before ~/.rbenv/shims. This
-#   is bad because it means that rbenv-installed programs don't have $PATH
-#   primacy anymore.
-PATH=./bin/stubs:~/.rbenv/shims:~/.rbenv/bin:$PATH
+eval "$(rbenv init -)"
+PATH=./bin/stubs:$PATH
 
 # }}}
 


### PR DESCRIPTION
I can't think of a time when I've run Ruby _inside_ Vim, and the whole "`rbenv init` must be in zshenv" thing is just confusing to people. Let's simplify.