### PR TITLE
Improve `install.sh`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -30,9 +30,6 @@ brew 'https://raw.githubusercontent.com/EricChiang/pup/master/pup.rb'
 # Qt5.5 for capybara-webkit, because Qt 5.6 doesn't work except with the most
 # recent version
 brew 'qt@5.5'
-# --overwrite: overwrite any Qt4 files that might be there
-# --force: required because Qt is keg-only
-`brew link --overwrite --force qt@5.5`
 
 # grep for ps
 brew 'pgrep'
@@ -97,5 +94,3 @@ brew 'yarn'
 brew 'nvm'
 
 brew 'parallel'
-# Overwrite the `parallel` from moreutils
-`brew link --overwrite parallel`

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+
+yellow() {
+  tput setaf 3
+  echo "$*"
+  tput sgr0
+}
+
+info(){
+  echo
+  yellow "$@"
+}
+
+quietly_brew_bundle(){
+  brew bundle --file="$1" | \
+    grep -vE '^(Using |Homebrew Bundle complete)' || \
+    true
+}
 
 is_osx(){
   [ "$(uname -s)" = Darwin ]
@@ -11,62 +28,69 @@ is_linux(){
 }
 
 if is_osx; then
-  echo "Checking for Homebrew..."
+  info "Installing Homebrew if not already installed..."
   if ! command -v brew > /dev/null; then
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    exit 1
   fi
 
-  echo "Installing Homebrew packages..."
-  brew update
+  info "Installing Homebrew packages..."
   brew tap homebrew/bundle
-  brew bundle -v --file=Brewfile
-  brew bundle -v --file=Brewfile.casks || true
-  for brewfile in */Brewfile; do
-    brew bundle --file="$brewfile" || true
+  for brewfile in Brewfile Brewfile.casks */Brewfile; do
+    quietly_brew_bundle "$brewfile"
   done
 
-  echo "Checking for command-line tools..."
+  # moreutils contains a `parallel` command, and Homebrew unlinks it when it
+  # sees the conflict. Relink them both.
+  brew link --overwrite parallel
+  brew link --overwrite moreutils
+  # --overwrite: overwrite any Qt4 files that might be there
+  # --force: required because Qt is keg-only
+  brew link --overwrite --force qt@5.5 &>/dev/null
+
+  info "Checking for command-line tools..."
   if ! command -v xcodebuild > /dev/null; then
     xcode-select --install
   fi
 fi
 
-if ! echo $SHELL | grep -Fq zsh; then
-  echo "Your shell is not Zsh. Changing it to Zsh..."
+if ! echo "$SHELL" | grep -Fq zsh; then
+  info "Your shell is not Zsh. Changing it to Zsh..."
   chsh -s /bin/zsh
 fi
 
-echo "Linking dotfiles into ~..."
+info "Linking dotfiles into ~..."
 # Before `rcup` runs, there is no ~/.rcrc, so we must tell `rcup` where to look.
 # We need the rcrc because it tells `rcup` to ignore thousands of useless Vim
 # backup files that slow it down significantly.
-RCRC=rcrc rcup -v -d .
+RCRC=rcrc rcup -d .
 
-echo "Installing zsh-syntax-highlighting..."
+info "Installing zsh-syntax-highlighting..."
 if [ ! -d ~/.zsh-plugins/zsh-syntax-highlighting ]; then
   git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.zsh-plugins/zsh-syntax-highlighting
 fi
 
-echo "Installing Vim packages..."
+info "Installing Vim packages..."
 vim +PlugInstall +qa
 
 if is_osx; then
-  echo
-  echo "If you like what you see in system/osx-settings, run ./system/osx-settings"
-  echo "If you're using Terminal.app, check out the terminal-themes directory"
+  info "If you like what you see in system/osx-settings, run ./system/osx-settings"
+  info "If you're using Terminal.app, check out the terminal-themes directory"
 fi
 
+info "Installing fonts..."
 if is_osx; then
-  if ! system_profiler SPFontsDataType | rg 'Full Name: Iosevka$'; then
+  if ! system_profiler SPFontsDataType | grep -Eq 'Full Name: Iosevka$'; then
     open fonts/iosevka*
   fi
 
-  if ! system_profiler SPFontsDataType | rg 'Full Name: Inconsolata Regular'; then
+  if ! system_profiler SPFontsDataType | grep -q 'Inconsolata-Regular'; then
     open fonts/Inconsolata*
   fi
 fi
 
+info "Running all setup scripts..."
 for setup in tag-*/setup; do
+  dir=$(basename "$(dirname "$setup")")
+  info "Running setup for ${dir#tag-}..."
   . "$setup"
 done


### PR DESCRIPTION
* Pretty-print what's happening
* Run shell scripts in `install.sh` instead of in `Brewfile`
* Suppress much more output so that the result of running the script isn't overwhelming
* Use `grep` instead of `rg` so I don't have to worry about whether `rg` has been installed at a given point in the script
* Use Bash instead of sh to get rid of some Shellcheck warnings (and /bin/sh is Bash on OSX anyway)
* Remove a stray `exit 1` (!!!)
* Don't run `brew update` since Homebrew does that automatically now