### PR TITLE
Don't use `rbenv init`

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -227,7 +227,23 @@ PATH=$HOME/.bin:$PATH
 # * ~/.rbenv/shims is before /usr/local/bin etc
 # * I don't know why it has to be in this order but putting shims before stubs
 #   breaks stubs ("You have activated the wrong version of rake" error)
-eval "$(rbenv init -)"
+PATH=$HOME/.rbenv/shims:$PATH
+export RBENV_SHELL=zsh
+source '/Users/gabe/.rbenv/libexec/../completions/rbenv.zsh'
+rbenv(){
+  local command
+  command="$1"
+  if [ "$#" -gt 0 ]; then
+    shift
+  fi
+
+  case "$command" in
+  rehash|shell)
+    eval "$(rbenv "sh-$command" "$@")";;
+  *)
+    command rbenv "$command" "$@";;
+  esac
+}
 PATH=./bin/stubs:$PATH
 
 # }}}


### PR DESCRIPTION
`eval $(rbenv init -)` is very slow. Some unscientific testing (wrapping my `.zshrc` in `time ( ... )`) led to the following measurements for `source ~/.zshrc`:

With `rbenv init`: usually ~285ms, with a max of 415ms (!) Without `rbenv init`: usually 177ms, with a max of 185ms

I tracked this difference in time (almost a third of a second sometimes!) to `rbenv rehash`, which `rbenv init -` always runs. I believe that my Zsh auto-rehashing (added in a00208ed4e34fa04501cb0ceb1c06443be296b5e) will take care of it.

The new code in `~/.zshrc` is exactly what `rbenv init -` was, without `rbenv rehash`.