### PR TITLE
Speed up how fast my zshrc loads

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -455,6 +455,10 @@ let test#ruby#rspec#options = {
       \ 'file':    '--format documentation',
       \ }
 
+" vim-ruby
+" -----------------
+let ruby_no_expensive = 1
+
 " luochen1990/rainbow
 " -----------------
 if expand("%:e") ==# 'clj'

--- a/zshrc
+++ b/zshrc
@@ -518,7 +518,9 @@ prompt_full_git_status(){
 # Here, it's used to capture the git status to show in the prompt.
 function precmd {
   vcs_info
-  git status 2> /dev/null >! "/tmp/git-status-$$"
+  if [[ -n "$vcs_info_msg_0_" ]]; then
+    git status 2> /dev/null >! "/tmp/git-status-$$"
+  fi
 }
 
 # Do I have a custom git email set for this git repo? Announce it so I remember

--- a/zshrc
+++ b/zshrc
@@ -253,8 +253,6 @@ PATH=./bin/stubs:$PATH
 # zmodload -i zsh/complist
 fpath=(~/.zsh/completion-scripts /usr/local/share/zsh/site-functions $fpath)
 autoload -U compinit && compinit
-# Now zsh understands bash completion files. Wild!
-autoload -U bashcompinit && bashcompinit
 
 # Try to match as-is then match case-insensitively
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
@@ -659,7 +657,19 @@ fi
 # Haskell {{{
 PATH="./.git/safe/../../.cabal-sandbox/bin:$HOME/.cabal/bin:$PATH"
 
-command -v stack > /dev/null && eval "$(stack --bash-completion-script stack)"
+if command -v stack > /dev/null; then
+  stack(){
+    # Delete this function so it only loads completion once.
+    unfunction stack
+
+    # Now zsh understands bash completion files. Wild!
+    autoload -U bashcompinit && bashcompinit
+    eval "$(stack --bash-completion-script stack)"
+
+    # Run the actual command I wanted to run.
+    stack "$@"
+  }
+fi
 
 new-yesod-project() {
   name=$1


### PR DESCRIPTION
* Only run `git status` when in a Git repo
* Load Stack completion on-demand
  * Loading `bashcompinit` and then Stack completion takes about 100ms from a cold start (and like 4ms from a hot one, when constantly loading zshrc lots of times in a row). This way I can load Stack completion on-demand the first time I run `stack`, and not have it take any time when I'm not doing any Haskell stuff. (Idea taken from here:  https://kev.inburke.com/kevin/profiling-zsh-startup-time/)
* Vim: set `ruby_no_expensive` for faster drawing