### PR TITLE
Show Spotify status in tmux status

### DIFF
--- a/bin/spotify-compact-status
+++ b/bin/spotify-compact-status
@@ -1,0 +1,22 @@
+#!/bin/sh
+# vim: textwidth=0
+
+# `spotify status` (from https://github.com/hnarayanan/shpotify) returns the
+# following:
+#
+#  Spotify is currently playing.
+#  Artist: Lewis Capaldi
+#  Album: Bruises
+#  Track: Bruises
+#  Position: 2:07 / 3:38
+#
+# That's way too long for a tmux status line (and take 0.75-1 seconds), so this
+# script uses osascript directly to return the following string in about 0.3
+# seconds:
+#
+# Bruises by Lewis Capaldi
+
+artist=$(osascript -e 'tell application "Spotify" to artist of current track as string')
+track=$(osascript -e 'tell application "Spotify" to name of current track as string')
+
+printf "%s by %s" "$track" "$artist"

--- a/tag-tmux/tmux.conf
+++ b/tag-tmux/tmux.conf
@@ -96,5 +96,5 @@ set-window-option -g window-status-current-fg red
 set -g status-interval 1
 set -g status-left-length 30
 set -g status-left '#[fg=white]#S #[default]'
-set -g status-right ''
-set -g status-right-length 40
+set -g status-right '#(~/.bin/spotify-compact-status) '
+set -g status-right-length 350


### PR DESCRIPTION
tmux automatically refreshes every `status-interval` seconds, so it always has the current Spotify song.