### PR TITLE
Don't start Spotify if it's not running

### DIFF
--- a/bin/spotify-compact-status
+++ b/bin/spotify-compact-status
@@ -15,8 +15,14 @@
 # seconds:
 #
 # Bruises by Lewis Capaldi
+#
+# If Spotify isn't running, it prints an empty string.
 
-artist=$(osascript -e 'tell application "Spotify" to artist of current track as string')
-track=$(osascript -e 'tell application "Spotify" to name of current track as string')
-
-printf "%s by %s" "$track" "$artist"
+applescript='
+var spotify = Application("Spotify");
+if (spotify.running()) {
+  track = spotify.currentTrack();
+  track.name() + " by " + track.artist();
+}
+'
+osascript -l JavaScript -e "$applescript"


### PR DESCRIPTION
tmux ran `spotify-compact-status` every second, and that script's AppleScript opened Spotify in order to query its status.

Now the `spotify-compact-status` checks if the application is actually running before asking for the status.

Also, I wrote it in JavaScript, because I vastly prefer AppleScript's JS interface.