### PR TITLE
Don't start Spotify when checking if it's running

### DIFF
--- a/bin/spotify-compact-status
+++ b/bin/spotify-compact-status
@@ -26,11 +26,19 @@ var statesToIcons = {
   paused: paused,
   stopped: stopped
 }
-var spotify = Application("Spotify");
 
-if (spotify.running()) {
+function namesOfRunningApplications(){
+  var systemEvents = Application('System Events');
+  return systemEvents.applicationProcesses().map(function(x) { return x.name() });
+}
+
+if (namesOfRunningApplications().indexOf('Spotify') > -1) {
+  var spotify = Application("Spotify");
+
   // stopped / playing / paused
   var state = spotify.playerState();
   var track = spotify.currentTrack();
-  statesToIcons[state] + " " + track.name() + " by " + track.artist();
+  if (track) {
+    statesToIcons[state] + " " + track.name() + " by " + track.artist();
+  }
 }

--- a/tag-tmux/tmux.conf
+++ b/tag-tmux/tmux.conf
@@ -93,7 +93,7 @@ set -g status-fg red
 # Highlight active window
 set-window-option -g window-status-current-bg white
 set-window-option -g window-status-current-fg red
-set -g status-interval 5
+set -g status-interval 1
 set -g status-left-length 30
 set -g status-left '#[fg=white]#S #[default]'
 set -g status-right '#(~/.bin/spotify-compact-status) '


### PR DESCRIPTION
`Application("Spotify").running()` will start Spotify (!) then check if it's running.

To work around this and check if Spotify is running _without_ starting it, use System Events and see if `Spotify` is in the names of running applications.

Now I can use a fast refresh in tmux without the 1-second refresh restarting Spotify before Spotify has a chance to shut down!

Also, sometimes when Spotify just started, `track` is `null`, so add a quick check around that.

More info here: https://stackoverflow.com/questions/16064957/how-to-check-in-applescript-if-an-app-is-running-without-launching-it-via-osa

@jcmorrow