### PR TITLE
No need to require Rubygems (and it breaks 2.5.0)

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -725,8 +725,6 @@ alias db-reset="DISABLE_DATABASE_ENVIRONMENT_CHECK=1 be rake db:drop db:create d
 alias f=start_foreman_on_unused_port
 alias unfuck-gemfile="git checkout HEAD -- Gemfile.lock"
 
-export RUBYOPT=rubygems
-
 # Bundler
 alias be="bundle exec"
 


### PR DESCRIPTION
Ruby 2.5.0 removed the "ubygems.rb" file:

> Removed "ubygems.rb" file from stdlib. It's needless since Ruby 1.9.

(Via https://github.com/ruby/ruby/blob/978be08b9db29cf190ef483320ed8c6d3df00091/doc/NEWS-2.5.0)

This means that `RUBYOPT=rubygems`, which translated to `ruby -rubygems`, which translated to `ruby --require ubygems` (neat, huh?), now breaks on Ruby 2.5.0.

I'm sort of shocked that this hasn't been a problem until now, given that I've been running 2.5.0 for weeks. The issue came up when I ran commands via `system()` in a Ruby script and saw errors about "ubygems.rb".

It turns out that Rubygems has been automatically included since Ruby 1.9, so the easiest _and_ most correct fix is simply to remove the option altogether.