### PR TITLE
Only run `rcup` when new files were added

### DIFF
--- a/tag-git/post-merge
+++ b/tag-git/post-merge
@@ -1,4 +1,18 @@
 #!/bin/sh
 
-echo ">>> Running rcup..."
-rcup -v | grep -v identical
+# This is the post-merge hook for _this dotfiles repo_.
+# It gets copied in by the `tag-git/setup` script.
+
+# If COPY_ALWAYS is set, then there are some copied (not symlinked) files and so
+# we always run rcup because we need to update them with `rcup`. They won't
+# automatically change when files in my dotfiles change.
+if ! grep -qF COPY_ALWAYS ~/.rcrc; then
+  added_files=$(git diff-tree --diff-filter=A -r --name-only --no-commit-id ORIG_HEAD HEAD)
+
+  if [ -n "$added_files" ]; then
+    echo ">>> Running rcup..."
+    rcup -v | grep -v identical
+  else
+    echo "No new files, not running rcup"
+  fi
+fi

--- a/tag-git/setup
+++ b/tag-git/setup
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "Installing Git hooks..."
 cp tag-git/post-merge .git/hooks/post-merge
 chmod +x .git/hooks/post-merge


### PR DESCRIPTION
Right now it runs even when an existing (and thus already symlinked) file is changed, which is unnecessary.

However, when an existing file is managed by rcm via COPYING (not symlinking), it won't be new (and thus won't trigger rcup), but because it's not symlinked, it'll be out of date in `$HOME`. Per the `rcrc` [docs](http://thoughtbot.github.io/rcm/rcrc.5.html), this is triggered by `COPY_ALWAYS` in `rcrc`, so if that's there, always run `rcrc` because I don't want to write something that's smart enough to detect if the changed files are in `COPY_ALWAYS`.