### PR TITLE
Vim: Highlight SQL in Ruby heredocs

### DIFF
--- a/vim/after/syntax/ruby.vim
+++ b/vim/after/syntax/ruby.vim
@@ -1,4 +1,4 @@
 unlet b:current_syntax
-syn include @SQL syntax/plsql.vim
+syn include @SQL syntax/sql.vim
 syn region sqlHeredoc start=/\v\<\<[-~]SQL/ end=/\vSQL/ keepend contains=@SQL
 let b:current_syntax = "ruby"

--- a/vimrc
+++ b/vimrc
@@ -532,6 +532,7 @@ Plug 'chase/vim-ansible-yaml'
 Plug 'chr4/nginx.vim'
 Plug 'Glench/Vim-Jinja2-Syntax'
 Plug 'slim-template/vim-slim'
+Plug 'shmup/vim-sql-syntax'
 
 " Arduino
 Plug 'stevearc/vim-arduino'


### PR DESCRIPTION
Downside: some colorschemes (like `Tomorrow-Night-Bright`) don't have highlighting set up to take full advantage of the new SQL colorings, but `jellybeans` and `molokai` do.