### PR TITLE
Load local git/tmux/vim configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ plug.vim.old
 
 # ASDF stores versions for all tools in this file
 tool-versions
+
+.vimrc.local
+.vimrc.bundles.local
+.tmux.conf.local
+.gitconfig.local

--- a/tag-git/gitconfig
+++ b/tag-git/gitconfig
@@ -141,3 +141,5 @@
   # Automatically stash before rebasing. This makes it possible to rebase with
   # changes in the repo.
   autostash = true
+[include]
+  path = ~/.gitconfig.local

--- a/tag-tmux/tmux.conf
+++ b/tag-tmux/tmux.conf
@@ -97,3 +97,5 @@ set -g status-left-length 30
 set -g status-left '#[fg=white]#S #[default]'
 set -g status-right '#(~/.bin/spotify-compact-status) '
 set -g status-right-length 350
+
+if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'

--- a/vimrc
+++ b/vimrc
@@ -615,6 +615,10 @@ Plug 'christoomey/vim-quicklink'
 " Make `gx` work on 'gabebw/dotfiles' too
 Plug 'gabebw/vim-github-link-opener'
 
+if filereadable($HOME . '/.vimrc.bundles.local')
+  source $HOME/.vimrc.bundles.local
+endif
+
 call plug#end()
 " }}}
 
@@ -646,6 +650,10 @@ augroup END
 
 if filereadable('.git/safe/../../.vimrc.local')
   source .vimrc.local
+endif
+
+if filereadable($HOME . '/.vimrc.local')
+  source $HOME/.vimrc.local
 endif
 
 call s:EnsureNothingConflictsWithGrep()


### PR DESCRIPTION
This will let me try things out locally without dirtying my git repo (and possibly accidentally committing some changes that I'm not yet sure of).

`vimrc.bundles.local` needs to be its own file so it can be sourced between `plug#begin` and `plug#end` function calls. Calling `plug#begin` and `plug#end` again clears Vim's knowledge of any other plugins; it doesn't add, it replaces.

Fixes #101.