### PR TITLE
Don't check for Ale

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -279,17 +279,15 @@ let g:gundo_prefer_python3 = 1
 augroup Ale
   autocmd!
   " ALE linting events
-  if exists('*ale#Lint')
-    set updatetime=1000
-    let g:ale_lint_on_text_changed = 'never'
-    let g:ale_linters = {}
-    " Run everything except rails_best_practices, which runs multiple processes
-    " and keeps all of my CPU cores at 100%.
-    let g:ale_linters.ruby = ['brakeman', 'reek', 'rubocop', 'ruby']
-    let g:ale_linters.javascript = ['eslint']
-    autocmd CursorHold * call ale#Lint()
-    autocmd InsertLeave * call ale#Lint()
-  endif
+  set updatetime=1000
+  let g:ale_lint_on_text_changed = 'never'
+  let g:ale_linters = {}
+  " Run everything except rails_best_practices, which runs multiple processes
+  " and keeps all of my CPU cores at 100%.
+  let g:ale_linters.ruby = ['brakeman', 'reek', 'rubocop', 'ruby']
+  let g:ale_linters.javascript = ['eslint']
+  autocmd CursorHold * call ale#Lint()
+  autocmd InsertLeave * call ale#Lint()
 augroup END
 " Move between linting errors
 nnoremap ]r :ALENextWrap<CR>


### PR DESCRIPTION
The `ale#Lint` function is defined after a file loads, I think, so even if Ale is installed, the function isn't defined at the time the `if` is evaluated. (I tried moving the `if` farther down my vimrc but it didn't change anything.)

The whole point of the `if` was to prevent Vim from crashing when running on a new computer. However, `install.sh` runs `vim +PlugInstall` just fine without Ale, so it can bootstrap itself just fine.

All of this points towards Just Removing The If.