### PR TITLE
Do double-source ASDF

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -377,7 +377,7 @@ export PROJECT_DIRECTORIES=$CDPATH
 # I truly do not want to deal with the hassle of GPG, so don't fail to install
 # when GPG isn't set up.
 export NODEJS_CHECK_SIGNATURES=no
-for f in /usr/local/etc/bash_completion.d/asdf.bash; do
+for f in /usr/local/opt/asdf/asdf.sh /usr/local/etc/bash_completion.d/asdf.bash; do
   [[ -r "$f" ]] && . "$f"
 done
 


### PR DESCRIPTION
Here's the order of Zsh startup files:

* First, read `/etc/zshenv`
* Next, read `~/.zshenv`
* Next, IF the shell is a login shell, read `/etc/zprofile`, followed by `~/.zprofile`
* Next, IF the shell is interactive, read `/etc/zshrc`, followed by `~/.zshrc`
* Finally, if the shell is a login shell, read `/etc/zlogin`, followed by `~/.zlogin`

In Vim, which runs a non-login non-interactive shell, only `/etc/zshenv` then `~/.zshenv` are run. Since the end of `~/.zshenv` puts ASDF at the front of the `$PATH`, ASDF's shims are correctly set up for Vim. (`:!which ruby` returns `/usr/local/opt/asdf/shims/ruby`).

However, in my daily usage, I run a login interactive shell, which means that `/etc/zprofile` gets run after `~/.zshenv`. And here's the contents of `/etc/zprofile`:

```
# system-wide environment settings for zsh(1)
if [ -x /usr/libexec/path_helper ]; then
        eval `/usr/libexec/path_helper -s`
fi
```

That `path_helper` line puts `/usr/local/bin` and `/usr/bin` (among others) at the front of the `$PATH`, which gives precedence to the Homebrew-installed Ruby at `/usr/local/bin/ruby` (or, even if that weren't installed, it'd just fall back to the system Ruby at `/usr/bin/ruby`). Thus, ASDF is clobbered.

We need to run ASDF:

* in `~/.zshenv` for Vim
* in `~/.zshrc` for everyday usage

So just run it twice. It's not an expensive script.

This reverts commit 39f2d43fa78a9265b8700d79e6036bdb18d4cc77.