### PR TITLE
reattach-to-user-namespace isn't needed anymore

### DIFF
--- a/helpful-tips/tmux.md
+++ b/helpful-tips/tmux.md
@@ -8,8 +8,7 @@ It works like in Vim:
 * `v` to start copying
 * `y` to copy and exit copy mode
 
-Now it's in the OSX global pasteboard (because of the
-`reattach-to-user-namespace` package), so you can do `Cmd-v` or `pbpaste`.
+Now it's in the OSX global pasteboard, so you can do `Cmd-v` or `pbpaste`.
 
 ## Choose sessions from a dropdown
 

--- a/tag-tmux/Brewfile
+++ b/tag-tmux/Brewfile
@@ -1,4 +1,1 @@
 brew 'tmux'
-
-# so copy/paste works in tmux
-brew 'reattach-to-user-namespace'

--- a/tag-tmux/tmux.conf
+++ b/tag-tmux/tmux.conf
@@ -4,9 +4,6 @@
 unbind C-b
 set -g prefix C-a
 
-# Make pbcopy/pbpaste and Vim's * register work.
-set -g default-command "reattach-to-user-namespace -l zsh"
-
 # Use emacs (readline) bindings to navigate the tmux command line (`<prefix>:`)
 set -g status-keys emacs
 
@@ -60,7 +57,7 @@ unbind s
 # copy-pipe-and-cancel. (copy-pipe-and-cancel exits copy mode after copying;
 # copy-pipe does not.)
 bind-key -T copy-mode-vi v send -X begin-selection
-bind-key -T copy-mode-vi y send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi y send -X copy-pipe-and-cancel pbcopy
 
 # Open a temporary split with gitsh
 bind g split-window -h -c '#{pane_current_path}' -p 30 'gitsh'


### PR DESCRIPTION
tmux and macOS started playing nicely together at some point recently.