### PR TITLE
Re-source vimrc when it changes

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -34,6 +34,9 @@ augroup vimrc
   au FileType ruby,eruby,yaml set iskeyword+=!,?
   au BufNewFile,BufRead,BufWrite *.md,*.markdown,*.html syntax match Comment /\%^---\_.\{-}---$/
   autocmd VimResized * wincmd =
+
+  " Re-source vimrc whenever it changes
+  autocmd BufWritePost vimrc,$MYVIMRC nested if expand("%") !~ 'fugitive' | source % | endif
 augroup END
 
 " vim-rails + vim-projectionist


### PR DESCRIPTION
I tried adding this in 5e2e309fc93aa6129c711d61c595f32dc8d422a1, but I had _two_ `augroup`s named "vimrc", and they conflicted so the auto-sourcing of the vimrc kept getting wiped.

To fix this, I added the `autocmd` to the existing `augroup vimrc`.

I confirmed that it really does work this time.

Fixes #110.