### PR TITLE
Easily expand a short Git SHA into a full one

### DIFF
--- a/vim/ftplugin/gitcommit.vim
+++ b/vim/ftplugin/gitcommit.vim
@@ -1,3 +1,5 @@
 " Spell-check Git messages
 setlocal spell
 setlocal colorcolumn=51
+
+nnoremap <buffer> gE :call ExpandShortGitShaIntoFullGitSha()<CR>

--- a/vimrc
+++ b/vimrc
@@ -477,6 +477,17 @@ set expandtab
 " ============================================================================
 " FUNCTIONS and COMMANDS {{{
 " ===========================================================================
+function! StripTrailingNewline(string)
+    return substitute(a:string, '\n\+$', '', '')
+endfunction
+
+function! ExpandShortGitShaIntoFullGitSha()
+  let short_sha = expand("<cword>")
+  let full_sha = StripTrailingNewline(system('git rev-parse ' . short_sha))
+  " Delete and replace SHA
+  exec 'normal! ciw' . full_sha
+endfunction
+
 function! s:EnsureNothingConflictsWithGrep()
   " I type `<Leader>g` to pop up `:Grep ` then quickly start typing my search
   " term. When (e.g.) `<Leader>gc` exists, I have to pause after `<Leader>g`


### PR DESCRIPTION
For example, it will expand aac6113 into aac611303692f5f272d52071e5391c83ff76826c.

Only enabled in gitcommit messages (at least for now).

Fixes #132.