### PR TITLE
Correctly trim off leading whitespace

### DIFF
--- a/bin/select-git-branch
+++ b/bin/select-git-branch
@@ -3,7 +3,7 @@
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 git branch --sort=-committerdate --color=always "$@" |\
-  sed -E -e 's/^[ \t]*//' |\
+  sed -E -e 's/^[[:space:]]*//' |\
   sed -E -e 's@^remotes/@@' |\
   rg -v '^\*' |\
   rg -v "remotes/origin/${current_branch}" |\


### PR DESCRIPTION
`[ \t]` apparently selects a literal space, a literal backslash, or a literal "t". It does not select a space or a tab (which is what I thought "\t" would select).

To fix this, use the POSIX character class `space`, which correctly finds any leading whitespace.