### PR TITLE
Fix extremely annoying vim-tmux-navigator issue

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -47,6 +47,17 @@ augroup rails_shortcuts
   autocmd User Rails nnoremap <Leader>v :Eview<Space>
   autocmd User Rails nnoremap <Leader>u :Eunittest<Space>
 augroup END
+
+" Don't let netrw override <C-l> to move between tmux panes
+" https://github.com/christoomey/vim-tmux-navigator/issues/189
+augroup netrw_mapping
+  autocmd!
+  autocmd filetype netrw call NetrwMapping()
+augroup END
+
+function! NetrwMapping()
+  nnoremap <silent> <buffer> <c-l> :TmuxNavigateRight<CR>
+endfunction
 " }}}
 
 " ============================================================================


### PR DESCRIPTION
This has been bothering me forever!

This worked perfectly: https://github.com/christoomey/vim-tmux-navigator/issues/189#issuecomment-620485838

To figure out that netrw was overriding the tmux map in the first place, I ran `:map <C-L>` and saw two mappings, then googled.