### PR TITLE
Fix fzf-tmux lockup/freeze

### DIFF
--- a/tag-tmux/tmux.conf
+++ b/tag-tmux/tmux.conf
@@ -33,7 +33,7 @@ bind -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
 bind -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
 
 unbind t
-bind t run-shell 'zsh -i -c t'
+bind t run-shell -b 'zsh -i -c t'
 
 # Equal-sized panes
 unbind =


### PR DESCRIPTION
The `t` command (`zsh -i -c t`) calls `fzf-tmux`, which as of tmux 3.0a now needs the `-b` argument to `run-shell` or else it locks up.

https://github.com/junegunn/fzf/issues/1841#issuecomment-580975759