### PR TITLE
Zsh: remove expensive call to `yarn`

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -404,10 +404,6 @@ PATH="/usr/local/heroku/bin:$PATH"
 # Node
 PATH=$PATH:.git/safe/../../node_modules/.bin/
 
-# This is a hack because Yarn globals don't get shimmed by ASDF.
-# Here's the issue: https://github.com/asdf-vm/asdf-nodejs/issues/42
-PATH=$(yarn global bin):$PATH
-
 # Python
 # Homebrew stores unversioned symlinks (e.g. `python` for `python3`) here, so
 # add them to the front so we always get Python 3.


### PR DESCRIPTION
`yarn global bin` added almost 0.3 seconds to shell startup - a big deal when I pop open a new shell quite often! After some testing, I think that everything I install with `yarn global add` is being found anyway, so the easiest fix is to just remove this line.