### PR TITLE
Fuzzy-find repos to clone for a given user

### DIFF
--- a/bin/recent-repos-owned-by
+++ b/bin/recent-repos-owned-by
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Gets the 30 most-recently-created repos under a given user, excluding forks.
+
+set -eo pipefail
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 USERNAME" >&2
+  exit 1
+fi
+
+user=$1
+hub api -t graphql -f query="{
+  user(login: \"$user\") {
+    repositories(first: 30, isFork: false, ownerAffiliations: OWNER, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        nameWithOwner
+      }
+    }
+  }
+}" | cut -f2

--- a/zshrc
+++ b/zshrc
@@ -809,6 +809,15 @@ function gcl {
   cd "$directory"
 }
 
+function gcl-fuzzy {
+  local user=${1?}
+  shift
+  local repo=$(recent-repos-owned-by "$user" | fzf)
+  echo $repo
+  local directory="$(superclone "$@" "$repo")"
+  cd "$directory"
+}
+
 new-project(){
   printf "Project name? "
   read project_name


### PR DESCRIPTION
Usage: `gcl-fuzzy gabebw`, which pops up FZF to select from that user's 30 most-recent repos, which I get from the new `recent-repos-owned-by` script.