### PR TITLE
Add a method to fuzzy-find and edit recent files

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -862,6 +862,12 @@ v(){
   [[ -n "$files" ]] && $VISUAL "${files[@]}"
   IFS=$old_IFS
 }
+# "vim recent", a quick and dirty version of https://github.com/rupa/v
+vr(){
+  local file=$(awk '/^>/ { sub(/^> /, "") ; print }' ~/.viminfo | fzf)
+  vim "${file/\~/$HOME}"
+}
+
 # Grep immediately on opening vim
 gv(){
   if [[ $# != 1 ]]; then


### PR DESCRIPTION
The `"${file/\~/$HOME}"` means "replace a literal ~ with $HOME", because we have to double-quote `"$file"` to handle spaces etc, but the double-quoting means that it won't do the ~ expansion and will literally look for a directory named `~`.