### PR TITLE
Prefer `main` branch name to `master`

### DIFF
--- a/bin/git-create-pull-request
+++ b/bin/git-create-pull-request
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # This script:
-# * creates a file with all of the commits since origin/master
+# * creates a file with all of the commits since origin/main
 # * Adds the pull request template (if it exists) above the list of commits
 # * intelligently reflows each commit's body to not have linebreaks (so that
 #   the PR looks better on GitHub, which keeps hard linebreaks)
@@ -192,7 +192,7 @@ class CommitMessageBuilder
     <<~MESSAGE
       # Descriptive title goes here
       #{pr_template.possible_body}
-      #{repo.fancy_log_of_all_commits_since_master}
+      #{repo.fancy_log_of_all_commits_since_main}
     MESSAGE
   end
 
@@ -211,13 +211,13 @@ class Repo
 
   attr_reader :current_branch
 
-  def fancy_log_of_all_commits_since_master
+  def fancy_log_of_all_commits_since_main
     fancy_format = "#{COMMIT_MARKER}%n(%aN, %ar)%n%n%w(78)%s%n%+b"
-    git "log --format='#{fancy_format}' origin/master..HEAD"
+    git "master-to-main-wrapper log --format='#{fancy_format}' origin/%BRANCH%..HEAD"
   end
 
   def number_of_commits
-    git("rev-list origin/master..HEAD --count").to_i
+    git("master-to-main-wrapper rev-list origin/%BRANCH%..HEAD --count").to_i
   end
 
   def first_commit_subject
@@ -232,8 +232,12 @@ class Repo
     git "log -1 --format=%B"
   end
 
-  def on_master?
+  def on_master_branch?
     current_branch == "master"
+  end
+
+  def on_main_branch?
+    current_branch == "main"
   end
 
   private
@@ -249,8 +253,8 @@ end
 
 repo = Repo.new
 
-if repo.on_master?
-  STDERR.puts "\n!!! You're already on master"
+if repo.on_main_branch? || repo.on_master_branch?
+  STDERR.puts "\n!!! You're already on #{current_branch}"
   exit 1
 end
 

--- a/bin/git-master-to-main-wrapper
+++ b/bin/git-master-to-main-wrapper
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+
+# Usage: instead of
+#
+#     git rebase -i master
+#
+# run this:
+#
+#     git master-to-main-wrapper rebase -i %BRANCH%
+#
+# It will replace the literal string `%BRANCH%` with "main" (preferred) or
+# "master" depending on what the current repository uses.
+
+command=$*
+branchname=$(main-or-master-branch)
+replaced_commands=$(echo $command | sed "s/%BRANCH%/$branchname/g")
+# sh_glob ignores special meaning of parentheses so that fancy logs like this
+# work: `git master-to-main-wrapper log --format='%w(78)%s%n%+b'`
+zsh -c "setopt sh_glob; git ${replaced_commands}"

--- a/bin/main-or-master-branch
+++ b/bin/main-or-master-branch
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+# Check if we should use the `main` or `master` branch for this repo.
+# Prefer `main` to `master`.
+
+if git show-ref --quiet origin/main || git rev-parse main &>/dev/null; then
+  echo main
+else
+  echo master
+fi

--- a/tag-git/bin/superclone
+++ b/tag-git/bin/superclone
@@ -23,7 +23,7 @@
 # * `gbw:paperclip`
 # * `gabebw/dotfiles` (clone GitHub repos by username/reponame)
 #
-# [my gitconfig]: https://github.com/gabebw/dotfiles/blob/master/gitconfig
+# [my gitconfig]: https://github.com/gabebw/dotfiles/blob/main/tag-git/gitconfig
 #
 # ## FAQ
 #

--- a/tag-git/gitconfig
+++ b/tag-git/gitconfig
@@ -37,10 +37,10 @@
   # My default `git log` format without color
   nocolor = log --pretty='%h%d %s [%an, %cr]'
   unstage = reset HEAD
-  mm-safe = !bundle exec rake && git merge-to master
-  mm = merge-to master
-  up = !git fetch origin && git rebase origin/master
-  r = rebase -i origin/master
+  mm-safe = !bundle exec rake && git merge-to main
+  mm = master-to-main-wrapper merge-to %BRANCH%
+  up = !git fetch origin && git master-to-main-wrapper rebase origin/%BRANCH%
+  r = master-to-main-wrapper rebase -i origin/%BRANCH%
   cp = cherry-pick
   # "cherry-pick previous", e.g. the head of the branch we just left
   cpp = cherry-pick HEAD@{1}

--- a/zshrc
+++ b/zshrc
@@ -61,7 +61,7 @@ curl-debug(){
 alias pgrep='command pgrep -f'
 alias split-on-spaces='tr " " "\n"'
 # dup = "dotfiles update"
-alias dup="pushd dotfiles && git checkout master &>/dev/null && git pull && git checkout - &>/dev/null && popd && qq"
+alias dup="pushd dotfiles && git checkout main &>/dev/null && git pull && git checkout - &>/dev/null && popd && qq"
 alias ...="cd ../.."
 # Copy-pasting `$ python something.py` works
 alias \$=''
@@ -736,7 +736,12 @@ PROMPT='$(prompt_tmux_status)$(prompt_ruby_version) $(prompt_shortened_path)$(pr
 # By itself: run `git status`
 # With arguments: acts like `git`
 function g {
-  if [[ $# > 0 ]]; then
+  if [[ $1 == init ]]; then
+    # Use "main", not "master"
+    git "$@"
+    git checkout -b main
+    git branch -d master
+  elif [[ $# > 0 ]]; then
     git "$@"
   else
     git st
@@ -795,7 +800,9 @@ function gb(){
     git checkout -b "$branch"
   fi
 }
-function gbm(){ git checkout -b "$1" origin/master }
+function gbm(){
+  git master-to-main-wrapper checkout -b "$1" "origin/%BRANCH%"
+}
 git-branch-with-prefix(){
   if [[ $# == 0 ]]; then
     echo "No branch name :(" >&2


### PR DESCRIPTION
## Why?
* https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx
* https://mail.gnome.org/archives/desktop-devel-list/2019-May/msg00066.html
  - https://github.com/bitkeeper-scm/bitkeeper/blob/5695c0d0ecd062f13542c3cb04dd872466774fbf/doc/HOWTO.ask#L232

## Technical details

This commit introduces `git-master-to-main-wrapper`, which seamlessly prefers `main` to `master` but works fine with repos that do use a `master` branch. To use it, prefix the git command with `master-to-main-wrapper`:

    git rebase -i master

becomes

    git master-to-main-wrapper rebase -i %BRANCH%

The `%BRANCH%` placeholder will becomes `main` or `master` as appropriate and the command will run. This means all of my aliases and scripts can be oblivious to branch name changes, and all of the branch-changing weirdness is centralized in one place.