### PR TITLE
Prettier integration for Ruby

### DIFF
--- a/prettierrc.json
+++ b/prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "preferSingleQuotes": false,
+  "inlineConditionals": false,
+  "inlineLoops": false
+}

--- a/tag-ruby/default-gems
+++ b/tag-ruby/default-gems
@@ -2,3 +2,4 @@ bundler <2
 awesome_print
 tmuxinator
 redcarpet
+prettier

--- a/vim/ale/fixers/ruby_prettier.vim
+++ b/vim/ale/fixers/ruby_prettier.vim
@@ -1,0 +1,22 @@
+call ale#Set('ruby_ruby_prettier_executable', 'rbprettier')
+call ale#Set('ruby_ruby_prettier_use_global', 1)
+call ale#Set('ruby_ruby_prettier_options', '')
+
+function! ale#fixers#ruby_prettier#GetExecutable(buffer) abort
+  let l:executable = ale#Var(a:buffer, 'ruby_ruby_prettier_executable')
+  let l:options = ale#Var(a:buffer, 'ruby_ruby_prettier_options')
+
+  return ale#ruby#EscapeExecutable(l:executable, 'rbprettier')
+        \ . ' --parser ruby'
+        \ . (!empty(l:options) ? ' ' . l:options : '')
+        \ . ' --stdin-filepath %s --stdin'
+endfunction
+
+function! ale#fixers#ruby_prettier#Fix(buffer) abort
+  return { 'command': ale#fixers#ruby_prettier#GetExecutable(a:buffer) }
+endfunction
+
+call ale#fix#registry#Add('ruby_prettier',
+      \ 'ale#fixers#ruby_prettier#Fix',
+      \ ['ruby'],
+      \ 'Fix Ruby files with Prettier')

--- a/vimrc
+++ b/vimrc
@@ -374,7 +374,7 @@ augroup Ale
   let g:ale_fixers.typescriptreact = ['prettier']
   let g:ale_fixers.css = ['prettier']
   let g:ale_fixers.scss = ['prettier']
-  let g:ale_fixers.ruby = ['rubocop']
+  let g:ale_fixers.ruby = ['ruby_prettier']
   let g:ale_fixers.rust = ['rustfmt']
 
   autocmd CursorHold * call ale#Queue(0)
@@ -748,6 +748,7 @@ endif
 call plug#end()
 " }}}
 
+source $HOME/.vim/ale/fixers/ruby_prettier.vim
 runtime macros/matchit.vim
 
 " vim-plug loads all the filetype, syntax and colorscheme files, so turn them on


### PR DESCRIPTION
The prettierrc options can't be in an `overrides` block with `files: *.rb` because we pass in files using the `--stdin` option, which loses the `.rb` extension. So, top-level it is.