### PR TITLE
fix case on QUIET

### DIFF
--- a/psqlrc
+++ b/psqlrc
@@ -36,4 +36,4 @@
 \set COMP_KEYWORD_CASE upper
 
 \setenv PAGER 'pspg --no-mouse -X -s5'
-\unset quiet
+\unset QUIET


### PR DESCRIPTION
Not sure if this is true for all versions but for me with pg 12,
the unset did not take effect with lowercase quiet