### PR TITLE
Use the full power of (neo)Vim in VS Code

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -82,3 +82,6 @@ brew "starship"
 
 # Git Large File Support
 brew "git-lfs"
+
+# Neovim, so I can use Vim in VS Code
+brew "neovim"

--- a/Library/Application Support/Code/User/settings.json
+++ b/Library/Application Support/Code/User/settings.json
@@ -115,6 +115,7 @@
     }
   ],
   "vim.useSystemClipboard": true,
+  "vscode-neovim.neovimExecutablePaths.darwin": "/usr/local/bin/nvim",
   "vsicons.dontShowNewVersionMessage": true,
   "window.zoomLevel": -1,
   "workbench.colorTheme": "Dracula",

--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -1,0 +1,20 @@
+" Use vimrc
+set runtimepath^=~/.vim runtimepath+=~/.vim/after
+let &packpath=&runtimepath
+source ~/.vimrc
+
+if exists('g:vscode')
+  " This block is running in VS Code.
+  " To tell VS Code to reload this file, reload VS Code with Cmd-r.
+
+  " For tips on how to use it effectively, see the excellent extension
+  " documentation:
+  " https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim
+
+  " To see what to call a given keybinding (e.g. `editor.action.rename`), see
+  " this page:
+  " https://vscode-docs.readthedocs.io/en/stable/customization/keybindings/
+
+  nnoremap gr <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
+  nnoremap gR <Cmd>call VSCodeNotify('editor.action.rename')<CR>
+endif

--- a/vscode/extensions
+++ b/vscode/extensions
@@ -1,15 +1,15 @@
 DotJoshJohnson.xml
-DotJoshJohnson.xml
 GitHub.vscode-pull-request-github
 GitLab.gitlab-workflow
 HookyQR.beautify
 KnisterPeter.vscode-github
+asvetliakov.vscode-neovim
 bodil.prettier-toml
 bungcip.better-toml
 castwide.solargraph
 dbaeumer.vscode-eslint
 dracula-theme.theme-dracula
-dracula-theme.theme-dracula
+dunstontc.viml
 eamodio.gitlens
 esbenp.prettier-vscode
 gamunu.vscode-yarn
@@ -23,5 +23,4 @@ statiolake.vscode-rustfmt
 sysoev.language-stylus
 usernamehw.errorlens
 vscode-icons-team.vscode-icons
-vscodevim.vim
 wingrunr21.vscode-ruby


### PR DESCRIPTION
The vscode-neovim extension sends commands to Vim, which means that I can get the full power of Vim (and its plugins) inside VS Code.

The extension uses Neovim because it provides a server for VS Code to connect to, but it just loads up my usual Vimrc and then sets some VS Code-specific keybindings.

For more on what it can do, see https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim

Fixes #190 