### PR TITLE
Make vim-plug fancy with Lua magic


### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -375,94 +375,93 @@ vim.o.shiftwidth = 2
 vim.o.expandtab = true
 
 -- Plugins
-vim.cmd([[
-call plug#begin(stdpath('config') . '/bundle')
-" JavaScript
+local Plug = require('vimplug')
+Plug.begin(vim.fn.stdpath('config') .. '/bundle')
+-- JavaScript
 Plug 'pangloss/vim-javascript'
 Plug 'MaxMEllon/vim-jsx-pretty'
 Plug 'leafgarland/typescript-vim'
 Plug 'peitalin/vim-jsx-typescript'
 
-" Ruby/Rails
+-- Ruby/Rails
 Plug 'tpope/vim-rails'
 Plug 'vim-ruby/vim-ruby'
-" Allow `cir` to change inside ruby block, etc
+-- Allow `cir` to change inside ruby block, etc
 Plug 'nelstrom/vim-textobj-rubyblock'
 Plug 'tpope/vim-rake'
 Plug 'tpope/vim-projectionist'
 Plug 'janko-m/vim-test'
 Plug 'dag/vim-fish'
 
-" tmux
+-- tmux
 Plug 'christoomey/vim-tmux-runner'
 Plug 'christoomey/vim-tmux-navigator'
 
-" Syntax
+-- Syntax
 Plug 'rust-lang/rust.vim'
 Plug 'vim-scripts/applescript.vim'
 Plug 'shmup/vim-sql-syntax'
 Plug 'tpope/vim-git'
 Plug 'cespare/vim-toml'
 
-" Plumbing that makes everything nicer
-" Fuzzy-finder
-Plug '/usr/local/opt/fzf' | Plug 'junegunn/fzf.vim'
-" Easily comment/uncomment lines in many languages
+-- Plumbing that makes everything nicer
+-- Fuzzy-finder
+-- Easily comment/uncomment lines in many languages
+Plug('junegunn/fzf.vim', { dependencies = { '/usr/local/opt/fzf' }})
 Plug 'tomtom/tcomment_vim'
-" <Tab> indents or triggers autocomplete, smartly
+
+-- <Tab> indents or triggers autocomplete, smartly
 Plug 'ervandew/supertab'
-" Git bindings
+-- Git bindings
 Plug 'tpope/vim-fugitive'
-" The Hub to vim-fugitive's git
+-- The Hub to vim-fugitive's git
 Plug 'tpope/vim-rhubarb'
-" Auto-add `end` in Ruby, `endfunction` in Vim, etc
+-- Auto-add `end` in Ruby, `endfunction` in Vim, etc
 Plug 'tpope/vim-endwise'
-" When editing deeply/nested/file, auto-create deeply/nested/ dirs
+-- When editing deeply/nested/file, auto-create deeply/nested/ dirs
 Plug 'duggiefresh/vim-easydir'
-" Cool statusbar
+-- Cool statusbar
 Plug 'itchyny/lightline.vim'
-" Easily navigate directories
+-- Easily navigate directories
 Plug 'tpope/vim-vinegar'
-" Make working with shell scripts nicer ("vim-unix")
+-- Make working with shell scripts nicer ("vim-unix")
 Plug 'tpope/vim-eunuch'
 Plug 'tpope/vim-surround'
-" Make `.` work to repeat plugin actions too
+-- Make `.` work to repeat plugin actions too
 Plug 'tpope/vim-repeat'
-" Intelligently reopen files where you left off
+-- Intelligently reopen files where you left off
 Plug 'farmergreg/vim-lastplace'
-" Instead of always copying to the system clipboard, use `cp` (plus motions) to
-" copy to the system clipboard. `cP` copies the current line. `cv` pastes.
+-- Instead of always copying to the system clipboard, use `cp` (plus motions) to
+-- copy to the system clipboard. `cP` copies the current line. `cv` pastes.
 Plug 'christoomey/vim-system-copy'
-" `vim README.md:10` opens README.md at the 10th line, rather than saying "No
-" such file: README.md:10"
+-- `vim README.md:10` opens README.md at the 10th line, rather than saying "No
+-- such file: README.md:10"
 Plug 'xim/file-line'
 Plug 'christoomey/vim-sort-motion'
 Plug 'flazz/vim-colorschemes'
 Plug 'sjl/gundo.vim'
-Plug 'xolox/vim-misc' | Plug 'xolox/vim-easytags'
-" Easily inspect registers exactly when you need them
-" https://github.com/junegunn/vim-peekaboo
+Plug('xolox/vim-easytags', { dependencies = { 'xolox/vim-misc' }})
+-- Easily inspect registers exactly when you need them
+-- https://github.com/junegunn/vim-peekaboo
 Plug 'junegunn/vim-peekaboo'
 
-" Text objects
-" required for all the vim-textobj-* plugins
+-- Text objects
+-- required for all the vim-textobj-* plugins
 Plug 'kana/vim-textobj-user'
-" `ae` text object, so `gcae` comments whole file
+-- `ae` text object, so `gcae` comments whole file
 Plug 'kana/vim-textobj-entire'
-" `l` text object for the current line excluding leading whitespace
+-- `l` text object for the current line excluding leading whitespace
 Plug 'kana/vim-textobj-line'
 
-" Markdown
+-- Markdown
 Plug 'tpope/vim-markdown'
-Plug 'nicholaides/words-to-avoid.vim', { 'for': 'markdown' }
-" It does more, but I'm mainly using this because it gives me markdown-aware
-" `gx` so that `gx` works on [Markdown](links).
-Plug 'christoomey/vim-quicklink', { 'for': 'markdown' }
-" Make `gx` work on 'gabebw/dotfiles' too
-Plug 'gabebw/vim-github-link-opener', { 'branch': 'main' }
-
-call plug#end()
-]])
+Plug('nicholaides/words-to-avoid.vim', { ft = 'markdown' })
+-- It does more, but I'm mainly using this because it gives me markdown-aware
+-- `gx` so that `gx` works on [Markdown](links).
+Plug('christoomey/vim-quicklink', { ft = 'markdown' })
+-- Make `gx` work on 'gabebw/dotfiles' too
+Plug('gabebw/vim-github-link-opener', { branch = 'main' })
+Plug.ends()
 
 vim.cmd [[
 augroup vimrc

--- a/config/nvim/lua/vimplug.lua
+++ b/config/nvim/lua/vimplug.lua
@@ -1,0 +1,78 @@
+-- From: https://dev.to/vonheikemen/neovim-using-vim-plug-in-lua-3oom
+-- I added some stuff, like `dependencies`.
+
+local configs = {
+  lazy = {},
+  start = {}
+}
+
+local Plug = {
+  begin = vim.fn['plug#begin'],
+
+  -- "end" is a keyword, need something else
+  ends = function()
+    vim.fn['plug#end']()
+
+    for i, config in pairs(configs.start) do
+      config()
+    end
+  end
+}
+
+local apply_config = function(plugin_name)
+  local fn = configs.lazy[plugin_name]
+  if type(fn) == 'function' then fn() end
+end
+
+local plug_name = function(repo)
+  return repo:match("^[%w-]+/([%w-_.]+)$")
+end
+
+-- "Meta-functions"
+local meta = {
+
+  -- Function call "operation"
+  __call = function(self, repo, opts)
+    opts = opts or vim.empty_dict()
+
+    -- -- Super basic, doesn't even accept opts yet, but doesn't need to (yet).
+    if opts.dependencies then
+      for _, dependency in pairs(opts.dependencies) do
+        vim.call('plug#', dependency, vim.empty_dict())
+      end
+    end
+
+    -- we declare some aliases for `do` and `for`
+    opts['do'] = opts.run
+    opts.run = nil
+
+    opts['for'] = opts.ft
+    opts.ft = nil
+
+    vim.call('plug#', repo, opts)
+
+    -- Add basic support to colocate plugin config
+    if type(opts.config) == 'function' then
+      local plugin = opts.as or plug_name(repo)
+
+      if opts['for'] == nil and opts.on == nil then
+        configs.start[plugin] = opts.config
+      else
+        configs.lazy[plugin] = opts.config
+        -- vim-plug calls `User` autocommands based on the name of the plugin
+        -- https://github.com/junegunn/vim-plug/blob/baa66bcf349a6f6c125b0b2b63c112662b0669e1/plug.vim#L630-L646
+        -- So we hook into that here.
+        vim.api.nvim_create_autocmd('User', {
+          pattern = plugin,
+          once = true,
+          callback = function()
+            apply_config(plugin)
+          end,
+        })
+      end
+    end
+  end
+}
+
+-- Meta-tables are awesome
+return setmetatable(Plug, meta)


### PR DESCRIPTION

The real reason to do this is that it provides an easy way to store a `config` for each plugin to be run when the plugin is loaded. This will make running plugin `setup` functions much easier later on.

You could make an argument that I should just switch to lazy.nvim at this point,
but I like that vim-plug doesn't bar me from re-sourcing my vimrc (as lazy
does).
