### PR TITLE
Switch to a TS LSP that ignores node_modules

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,7 +1,9 @@
 [tools]
 java = "latest"
 node = "lts"
+"npm:typescript" = "latest"
 ruby = "3.4.5"
+"npm:typescript-language-server" = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["ruby", "node"]

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -554,6 +554,7 @@ require("lazy").setup({
     {
       "neovim/nvim-lspconfig",
       config = function()
+        require("lspconfig").ts_ls.setup({})
         require("lspconfig").ruby_lsp.setup({
           cmd = { "ruby-lsp" },
           init_options = {
@@ -640,12 +641,6 @@ require("lazy").setup({
           },
         },
       },
-    },
-
-    {
-      "pmizio/typescript-tools.nvim",
-      dependencies = { "nvim-lua/plenary.nvim", "neovim/nvim-lspconfig" },
-      opts = {},
     },
 
     { "folke/lazydev.nvim", opts = {} },
@@ -964,7 +959,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
     -- Fuzzy find all the symbols in your current workspace.
     --  Similar to document symbols, except searches over your entire project.
-    map("<leader>ws", t.lsp_dynamic_workspace_symbols, "[W]orkspace [S]ymbols")
+    map("<leader>ws", t.lsp_workspace_symbols, "[W]orkspace [S]ymbols")
   end,
 })
 

--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -22,7 +22,6 @@
   "telescope-undo.nvim": { "branch": "main", "commit": "928d0c2dc9606e01e2cc547196f48d2eaecf58e5" },
   "telescope.nvim": { "branch": "master", "commit": "b4da76be54691e854d3e0e02c36b0245f945c2c7" },
   "trouble.nvim": { "branch": "main", "commit": "85bedb7eb7fa331a2ccbecb9202d8abba64d37b3" },
-  "typescript-tools.nvim": { "branch": "master", "commit": "3c501d7c7f79457932a8750a2a1476a004c5c1a9" },
   "typescript-vim": { "branch": "master", "commit": "4740441db1e070ef8366c888c658000dd032e4cb" },
   "vim-colorschemes": { "branch": "master", "commit": "fd8f122cef604330c96a6a6e434682dbdfb878c9" },
   "vim-easydir": { "branch": "master", "commit": "2efbed9e24438f626971a526d19af719b89e8040" },


### PR DESCRIPTION

It's very frustrating that typescript-tools.nvim includes symbols in `node_modules` when I ask for `lsp_dynamic_workspace_symbols` (or `lsp_workspace_symbols`). I don't know how to fix it, and it's an ongoing issue in the GitHub issues, so I switched to `ts_ls` and it Just Works.

I changed `lsp_dynamic_workspace_symbols` to `lsp_workspace_symbols` because the latter is a bit faster, and I don't really know what `dynamic` adds for me. But to be clear, the `ts_ls` thing is the part that fixes the `node_modules` issue. This is just a little faster.

As part of this, tell Mise to install typescript-language-server.
