### PR TITLE
simple_format: Markdown-ish formatting in my shell

### DIFF
--- a/bin/simple_format
+++ b/bin/simple_format
@@ -1,0 +1,23 @@
+#!/usr/bin/env fish --no-config
+
+# For more about the codes you can pass to `tput`, see here: https://www.mankier.com/5/terminfo#Description-Predefined_Capabilities
+
+function replacement_command -a character
+  set -f codes $argv[2..]
+  set -f formatting ""
+  for code in $codes
+    set formatting $formatting(tput $code)
+  end
+  # sgr0 = remove all formatting and reset to normal
+  echo "s|$character([^$character[1]]+)$character|"$formatting'\1'(tput sgr0)'|g'
+end
+
+sed -E \
+  # Bold
+  -e (replacement_command '\*\*' bold) \
+  # Italics - must be after Bold or else it steals the *s first
+  -e (replacement_command '\*' sitm) \
+  # Underline
+  -e (replacement_command '_' ssubm) \
+  # Code snippet: shown bold and reversed
+  -e (replacement_command '`' bold rev)

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -414,6 +414,6 @@ if status --is-interactive
     # -C <path>: Run as if git was started in <path> instead of the current working directory
     set -f dotfiles_git_dir (git -C (dirname $this_file) rev-parse --show-toplevel)
     # Fortune doesn't like `~/.habits`, so point it directly here
-    fortune $dotfiles_git_dir/habits
+    fortune $dotfiles_git_dir/habits | simple_format
   end
 end


### PR DESCRIPTION
It supports **bold**, *italic*, _underline_, and `code`.

Check it out: this very commit message, formatted with `simple_format` (with fix from 5e41e19d071ad6067913ddd30ae6d677ca029fd3):

<img width="1168" height="418" alt="CleanShot 2025-09-25 at 21 46 28@2x" src="https://github.com/user-attachments/assets/e47f778b-b474-419a-99fb-6159cdd007b1" />